### PR TITLE
Utilize more of CPU core 1

### DIFF
--- a/snes9x_3ds.rsf
+++ b/snes9x_3ds.rsf
@@ -73,7 +73,7 @@ AccessControlInfo:
  
   Priority                      : 16
  
-  MaxCpu                        : 0x9E # Default
+  MaxCpu                        : 0
  
   DisableDebug                  : false
   EnableForceDebug              : false

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -292,7 +292,7 @@ bool impl3dsInitializeCore()
     Settings.NetPlay = FALSE;
 	Settings.NoPatch = TRUE;
     Settings.ServerName [0] = 0;
-    Settings.ThreadSound = FALSE;
+    Settings.ThreadSound = TRUE;
     Settings.AutoSaveDelay = 60;         // Bug fix to save SRAM within 60 frames (1 second instead of 30 seconds)
 #ifdef _NETPLAY_SUPPORT
     Settings.Port = NP_DEFAULT_PORT;

--- a/source/3dssound.cpp
+++ b/source/3dssound.cpp
@@ -355,10 +355,10 @@ bool snd3dsInitialize()
     {
 #ifdef LIBCTRU_1_0_0
         //aptOpenSession();
-        APT_SetAppCpuTimeLimit(30); // enables syscore usage
+        APT_SetAppCpuTimeLimit(70); // enables syscore usage
         //aptCloseSession();   
 #else
-        APT_SetAppCpuTimeLimit(30); // enables syscore usage
+        APT_SetAppCpuTimeLimit(70); // enables syscore usage
 #endif
 
 #ifndef RELEASE


### PR DESCRIPTION
Hi I noticed that you were only using 30% of CPU Core 1. I found that you can use up to %70 by removing the limit in the rsf file.